### PR TITLE
Update TIME_MARGIN before doing since/until Voiding time checks

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -567,6 +567,7 @@ if (!process.env.EB_NODE_COMMAND) {
                                 var result = JSON.parse(res.body);
                                 lrsTime = new Date(result.stored);
                                 TIME_MARGIN = suiteTime - lrsTime;
+                                // console.log("TimeMargin set to " + TIME_MARGIN);
                                 done(err, TIME_MARGIN);
                             } else {
                                 setTimeout(redo, 2000);

--- a/test/v1_0_3/H.Communication2.1-StatementResource.js
+++ b/test/v1_0_3/H.Communication2.1-StatementResource.js
@@ -2659,6 +2659,10 @@ MUST have a "Content-Type" header
         var sinceVoidingTime, untilVoidingTime;
         var stmtTime, prevStmtTime;
 
+        before("Update TimeMargin to better reflect current time differential between test suite and lrs", function (done) {
+            helper.setTimeMargin(done);
+        });
+
         before('persist voided statement', function (done) {
             // console.log(new Date(Date.now() - helper.getTimeMargin()).toISOString() + ' Ed Before');
             sinceVoidingTime = new Date(Date.now() - helper.getTimeMargin() - 4000).toISOString();

--- a/test/v2_0/4.1.6.1-Statement-Resource.js
+++ b/test/v2_0/4.1.6.1-Statement-Resource.js
@@ -2724,6 +2724,10 @@ describe('Statement Resource Requirements (Communication 2.1)', () => {
         var sinceVoidingTime, untilVoidingTime;
         var stmtTime, prevStmtTime;
 
+        before("Update TimeMargin to better reflect current time differential between test suite and lrs", function (done) {
+            helper.setTimeMargin(done);
+        });
+
         before('persist voided statement', function (done) {
             // console.log(new Date(Date.now() - helper.getTimeMargin()).toISOString() + ' Ed Before');
             sinceVoidingTime = new Date(Date.now() - helper.getTimeMargin() - 4000).toISOString();


### PR DESCRIPTION
This is a fix for Issue https://github.com/RusticiSoftware/ScormEngine/issues/9230 which details Nightly failures on the 24.x branch when running the ripformance tests against **saphana**.

### Background

When the **LRS** test suite first starts up it tries to determine the difference between the machine running the test suite and the actual **LRS** by taking a timestamp, submitting a statement to be stored to the **LRS**, and then waiting for that statement to be returned from the **POST** request and using the "stored" value from the **LRS** to determine the latency between the two machines.  This latency in essence then allows the test suite to adjust times on the test suite versus times on the **LRS** by subtracting that value.   The **TIME_MARGIN** is a negative number representing essentially the milliseconds it takes to process a request on the server.  Part of the issue is that for the VERY FIRST REQUEST made to the server ... it takes a lot longer than subsequent requests as the **LRS** typically has to do startup (loading caches, database index loading, etc.)

The test case that routinely fails in the test suite is:
`should only return statements stored at or before designated "before" timestamp when using "until" parameter` because the statement it expects to find does not fall in the since/until timeframe.   The since value is determined by:
`sinceVoidingTime = new Date(Date.now() - helper.getTimeMargin() - 4000).toISOString();
`

In testing it was found the following TIME_MARGIN values were set when running the **1.0.3** test suite followed by the **2.0.0** test suite:

- **MySQL** -1247 ms and -161 ms
- **SQLServer** -1633 ms and -170 ms
- **PostGres** -1106 ms and -114 ms
- **SAP** -2171 ms and -362 ms

When looking at the actual Nightly 24.x runs for SAP Hana the last time the job succeeded you can see from the rusticiengine.log:
INFO  2026-02-25 20:10:14 UTC – Logging request for /RusticiEngine/lrs//statements: {"credential_type":"basicUser","agent":"","client":"172.29.0.5","remaining_params":[],"httpMethod":"POST","url":"http://engine-inst:8000/RusticiEngine/lrs//statements","timestamp":"2026-02-25T20:10:14.742Z","server_engine":"c4c60ca86e0b","credential_id":"root"}
INFO  2026-02-25 20:10:14 UTC – ***USING ROOT TCAPI ACCOUNT FOR TCAPI ACCESS***
INFO  2026-02-25 20:10:15 UTC – Initialized memory cache for 'xapiStatement' with expiry 600000 ms
INFO  2026-02-25 20:10:15 UTC – TCAPI handler processed method POST for URL: /RusticiEngine/lrs//statements in 1110 milliseconds

The request took about 1 second to complete.

for the latest run that failed:
INFO  2026-03-07 04:20:48 UTC – Logging request for /RusticiEngine/lrs//statements: {"credential_type":"basicUser","agent":"","client":"192.168.16.5","remaining_params":[],"httpMethod":"POST","url":"http://engine-inst:8000/RusticiEngine/lrs//statements","timestamp":"2026-03-07T04:20:48.681Z","server_engine":"400b6572f844","credential_id":"root"}
INFO  2026-03-07 04:20:53 UTC – ***USING ROOT TCAPI ACCOUNT FOR TCAPI ACCESS***
INFO  2026-03-07 04:20:53 UTC – Initialized memory cache for 'xapiStatement' with expiry 600000 ms
INFO  2026-03-07 04:20:54 UTC – TCAPI handler processed method POST for URL: /RusticiEngine/lrs//statements in 5204 milliseconds

So the one that failed took more than 5 seconds to respond ... using that value for the TIME_MARGIN (roughly) it's easy to see why the sinceVoidingTime had an issue:

The **TIME_MARGIN** is actually larger than the 4 seconds that the test suite relies on for setting the "since" value.   The easiest solution was to reset the **TIME_MARGIN** in both tests at the top of the test suites that specifically set the **sinceVoidingTime** by re-calling **setTimeMargin** as part of the first before item for that set of tests:

```
        before("Update TimeMargin to better reflect current time differential between test suite and lrs", function (done) {
            helper.setTimeMargin(done);
        });
```

By resetting the value used for TIME_MARGIN just before the test needs to use it for something very time critical gives a more realistic value for computed since/until values.